### PR TITLE
Tweaks for external grabber

### DIFF
--- a/source/app.c
+++ b/source/app.c
@@ -238,7 +238,7 @@ void app_run(app_t *self, int target_fps) {
 	timer_t *frame_timer = timer_create();
 
 	while( true ) {
-		if ( connections > 0 ) {
+		if( connections > 0 ) {
 			double delta = timer_delta(frame_timer);
 			if( delta > wait_time ) {
 				fps = fps * 0.95f + 50.0f/delta;
@@ -249,17 +249,19 @@ void app_run(app_t *self, int target_fps) {
 					pixels = grabber_grab(self->grabber);
 				}
 
-				double encode_time = timer_measure(encode_time) {
-					size_t encoded_size = APP_FRAME_BUFFER_SIZE - sizeof(jsmpeg_frame_t);
-					encoder_encode(self->encoder, pixels, frame->data, &encoded_size);
+				if( pixels != NULL ) {
+					double encode_time = timer_measure(encode_time) {
+						size_t encoded_size = APP_FRAME_BUFFER_SIZE - sizeof(jsmpeg_frame_t);
+						encoder_encode(self->encoder, pixels, frame->data, &encoded_size);
 				
-					if( encoded_size ) {
-						frame->size = swap_int32(sizeof(jsmpeg_frame_t) + encoded_size);
-						server_broadcast(self->server, frame, sizeof(jsmpeg_frame_t) + encoded_size, server_type_binary);
+						if( encoded_size ) {
+							frame->size = swap_int32(sizeof(jsmpeg_frame_t) + encoded_size);
+							server_broadcast(self->server, frame, sizeof(jsmpeg_frame_t) + encoded_size, server_type_binary);
+						}
 					}
+
+					printf("fps:%3d (grabbing:%6.2fms, scaling/encoding:%6.2fms)\r", (int)fps, grab_time, encode_time);
 				}
-			
-				printf("fps:%3d (grabbing:%6.2fms, scaling/encoding:%6.2fms)\r", (int)fps, grab_time, encode_time);
 			}
 		}
 

--- a/source/grabber.c
+++ b/source/grabber.c
@@ -77,8 +77,10 @@ void grabber_destroy(grabber_t *self) {
 }
 
 void *grabber_grab(grabber_t *self) {
-	if ( self->dll > 0 ) {
-		self->dll_grab(self->pixels, self->width, self->height);
+	if( self->dll > 0 ) {
+		if( self->dll_grab(self->window, self->pixels, self->width, self->height) == 0) {
+			return NULL;
+		}
 	} else {
 		SelectObject(self->memoryDC, self->bitmap);
 		BitBlt(self->memoryDC, 0, 0, self->width, self->height, self->windowDC, self->crop.x, self->crop.y, SRCCOPY);

--- a/source/grabber.h
+++ b/source/grabber.h
@@ -7,7 +7,7 @@
 
 typedef void (__cdecl* dll_grabber_create)(HWND window, int& width, int& height);
 typedef void (__cdecl* dll_grabber_destroy)();
-typedef void (__cdecl* dll_grabber_grab)(void* pixels, int width, int height);
+typedef int (__cdecl* dll_grabber_grab)(HWND window, void* pixels, int width, int height);
 
 typedef struct {
 	int x, y, width, height;


### PR DESCRIPTION
- pass window hwnd in `dll_grab`
- add integer return value to `dll_grab` treated as a boolean.
- if `dll_grab` returns false set `pixels` to `NULL` which will skip the encoding/broadcasting step.

These changes are required for https://github.com/ollydev/jsmpeg-vnc-desktop-duplication/releases which now supports capturing a window:

Chrome without desktop duplication: https://i.imgur.com/SxqfYEx.png
Chrome with desktop duplication: https://i.imgur.com/X3BiMl6.png

